### PR TITLE
Pin cert-manager module version

### DIFF
--- a/modules/add-ons/adot-operator/main.tf
+++ b/modules/add-ons/adot-operator/main.tf
@@ -1,5 +1,5 @@
 module "cert_manager" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints/modules/kubernetes-addons/cert-manager"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/cert-manager?ref=v4.8.1"
   count  = var.enable_cert_manager ? 1 : 0
 
   helm_config   = var.helm_config


### PR DESCRIPTION
### What does this PR do?

Pin eks-blueprint cert-manager version. This fixes an issue for an upstream requirement

