### PR TITLE
Updating nginx otel log level

### DIFF
--- a/modules/workloads/nginx/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/workloads/nginx/otel-config/templates/opentelemetrycollector.yaml
@@ -50,7 +50,7 @@ spec:
         auth:
           authenticator: sigv4auth
       logging:
-          loglevel: debug
+          loglevel: info
     extensions:
       sigv4auth:
         region: {{ .Values.region }}


### PR DESCRIPTION
### What does this PR do?

Changes the nginx module otel logging level to 'info' from 'debug'



### Motivation

Debug would provide too verbose logging.


### More

- [ X ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [X] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
