### PR TITLE
doc: Update Managed Grafana instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If you are interested in contributing to EKS Blueprints, see the [Contribution g
 | <a name="output_eks_cluster_version"></a> [eks\_cluster\_version](#output\_eks\_cluster\_version) | EKS Cluster version |
 | <a name="output_grafana_dashboards_folder_id"></a> [grafana\_dashboards\_folder\_id](#output\_grafana\_dashboards\_folder\_id) | Grafana folder ID for automatic dashboards. Required by workload modules |
 | <a name="output_managed_grafana_workspace_endpoint"></a> [managed\_grafana\_workspace\_endpoint](#output\_managed\_grafana\_workspace\_endpoint) | Amazon Managed Grafana workspace endpoint |
+| <a name="output_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#output\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana workspace ID |
 | <a name="output_managed_prometheus_workspace_endpoint"></a> [managed\_prometheus\_workspace\_endpoint](#output\_managed\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus workspace endpoint |
 | <a name="output_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#output\_managed\_prometheus\_workspace\_id) | Amazon Managed Prometheus workspace ID |
 | <a name="output_managed_prometheus_workspace_region"></a> [managed\_prometheus\_workspace\_region](#output\_managed\_prometheus\_workspace\_region) | Amazon Managed Prometheus workspace region |

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -60,7 +60,12 @@ If you don't specify anything a new workspace will be created for you.
 
 6. Amazon Managed Grafana workspace
 
-If you have an existing workspace, create an environment variable `export TF_VAR_managed_grafana_workspace_id=g-xxx`.
+To run this example you need an Amazon Managed Grafana workspace. If you have an existing workspace, create an environment variable `export TF_VAR_managed_grafana_workspace_id=g-xxx`.
+
+To create a new one, within this example's Terraform state (sharing the same lifecycle with all the other resources):
+
+- Edit main.tf and set `enable_managed_grafana = true`
+- Run `terraform apply -var-file=dev.tfvars -target "module.eks_observability_accelerator.module.managed_grafana[0].aws_grafana_workspace.this[0]"`.
 
 7. <a name="apikey"></a> Grafana API Key
 

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -66,6 +66,7 @@ To create a new one, within this example's Terraform state (sharing the same lif
 
 - Edit main.tf and set `enable_managed_grafana = true`
 - Run `terraform apply -var-file=dev.tfvars -target "module.eks_observability_accelerator.module.managed_grafana[0].aws_grafana_workspace.this[0]"`.
+- Run `export TF_VAR_managed_grafana_workspace_id=$(terraform output managed_grafana_workspace_id)`.
 
 7. <a name="apikey"></a> Grafana API Key
 

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -187,6 +187,7 @@ terraform destroy -var-file=terraform.tfvars
 | <a name="output_eks_cluster_id"></a> [eks\_cluster\_id](#output\_eks\_cluster\_id) | EKS Cluster Id |
 | <a name="output_eks_cluster_version"></a> [eks\_cluster\_version](#output\_eks\_cluster\_version) | EKS Cluster version |
 | <a name="output_grafana_dashboard_urls"></a> [grafana\_dashboard\_urls](#output\_grafana\_dashboard\_urls) | URLs for dashboards created |
+| <a name="output_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#output\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana workspace ID |
 | <a name="output_managed_prometheus_workspace_endpoint"></a> [managed\_prometheus\_workspace\_endpoint](#output\_managed\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus workspace endpoint |
 | <a name="output_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#output\_managed\_prometheus\_workspace\_id) | Amazon Managed Prometheus workspace ID |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -65,8 +65,8 @@ To run this example you need an Amazon Managed Grafana workspace. If you have an
 To create a new one, within this example's Terraform state (sharing the same lifecycle with all the other resources):
 
 - Edit main.tf and set `enable_managed_grafana = true`
-- Run `terraform apply -var-file=dev.tfvars -target "module.eks_observability_accelerator.module.managed_grafana[0].aws_grafana_workspace.this[0]"`.
-- Run `export TF_VAR_managed_grafana_workspace_id=$(terraform output managed_grafana_workspace_id)`.
+- Run `terraform apply -target "module.eks_observability_accelerator.module.managed_grafana[0].aws_grafana_workspace.this[0]"`.
+- Run `export TF_VAR_managed_grafana_workspace_id=$(terraform output --raw managed_grafana_workspace_id)`.
 
 7. <a name="apikey"></a> Grafana API Key
 

--- a/examples/existing-cluster-with-base-and-infra/outputs.tf
+++ b/examples/existing-cluster-with-base-and-infra/outputs.tf
@@ -23,6 +23,11 @@ output "managed_prometheus_workspace_id" {
   value       = module.eks_observability_accelerator.managed_prometheus_workspace_id
 }
 
+output "managed_grafana_workspace_id" {
+  description = "Amazon Managed Grafana workspace ID"
+  value       = module.eks_observability_accelerator.managed_grafana_workspace_id
+}
+
 output "grafana_dashboard_urls" {
   description = "URLs for dashboards created"
   value       = module.workloads_infra.grafana_dashboard_urls

--- a/locals.tf
+++ b/locals.tf
@@ -26,6 +26,7 @@ locals {
   # if grafana_workspace_id is supplied, we infer the endpoint from
   # computed region, else we create a new workspace
   amg_ws_endpoint = var.managed_grafana_workspace_id == "" ? "https://${module.managed_grafana[0].workspace_endpoint}" : "https://${data.aws_grafana_workspace.this[0].endpoint}"
+  amg_ws_id       = var.managed_grafana_workspace_id == "" ? split(".", module.managed_grafana[0].workspace_endpoint)[0] : var.managed_grafana_workspace_id
 
   context = {
     aws_caller_identity_account_id = data.aws_caller_identity.current.account_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,11 @@ output "managed_grafana_workspace_endpoint" {
   value       = local.amg_ws_endpoint
 }
 
+output "managed_grafana_workspace_id" {
+  description = "Amazon Managed Grafana workspace ID"
+  value       = local.amg_ws_id
+}
+
 output "grafana_dashboards_folder_id" {
   description = "Grafana folder ID for automatic dashboards. Required by workload modules"
   value       = grafana_folder.this.id


### PR DESCRIPTION
- Update Managed Grafana instructions for infrastructure monitoring example
- Add output for grafana workspace id `managed_grafana_workspace_id`
- Updates docs

Linked to #47 