### PR TITLE
Update kuberenetes and instance type

### DIFF
--- a/examples/eks-cluster-with-vpc/main.tf
+++ b/examples/eks-cluster-with-vpc/main.tf
@@ -44,7 +44,7 @@ module "eks_blueprints" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.13.1"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.23"
+  cluster_version = "1.24"
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets
@@ -52,7 +52,7 @@ module "eks_blueprints" {
   managed_node_groups = {
     mg_5 = {
       node_group_name = "managed-ondemand"
-      instance_types  = ["t3.xlarge"]
+      instance_types  = ["t4.xlarge"]
       min_size        = 2
       subnet_ids      = module.vpc.private_subnets
     }


### PR DESCRIPTION
### What does this PR do?

Updating the Cluster's Kubernetes version and the instance types for the managed node group.

### Motivation

When deploying the EKS cluster i found that the add-ons would fail and the first thing i would need to do is upgrade the cluster's version. 

Upgrading the instance type as a best practice. 

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [N/A] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [N/A] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [x] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

