### PR TITLE
Update the usage of set-output command in GH actions

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -30,7 +30,7 @@ jobs:
         id: dirs
         run: |
           DIRS=$(python3 .github/workflows/plan-examples.py)
-          echo "::set-output name=directories::$DIRS"
+          echo "directories=$DIRS" >> $GITHUB_OUTPUT
 
   plan:
     name: Plan examples


### PR DESCRIPTION
### What does this PR do?

This PR updates the usage of set-output command in GH actions.

Reference : https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!-- A brief description of the change being made with this pull request. -->

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.


### Motivation

<!-- What inspired you to submit this pull request? -->

Volunteer


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
