### PR TITLE
fix: EKS cluster with VPC revert to t3 instances

### DIFF
--- a/examples/eks-cluster-with-vpc/main.tf
+++ b/examples/eks-cluster-with-vpc/main.tf
@@ -52,7 +52,7 @@ module "eks_blueprints" {
   managed_node_groups = {
     mg_5 = {
       node_group_name = "managed-ondemand"
-      instance_types  = ["t4.xlarge"]
+      instance_types  = ["t3.xlarge"]
       min_size        = 2
       subnet_ids      = module.vpc.private_subnets
     }


### PR DESCRIPTION
### What does this PR do?

T4 instances are not generally available, with [this issue](https://github.com/aws-observability/terraform-aws-observability-accelerator/issues/89) we'll provide customization options
