### PR TITLE
Added parameter for instance type

### DIFF
--- a/docs/helpers/new-eks-cluster.md
+++ b/docs/helpers/new-eks-cluster.md
@@ -32,6 +32,22 @@ Specify the AWS Region where the resources will be deployed:
 export TF_VAR_aws_region=xxx
 ```
 
+### 3. Instance Type
+
+Depending on your region or limitations in your account, you might need to change to a different instance type.
+To do this, you can define the instance type to use:
+```bash
+export TF_VAR_managed_node_instance_type=xxx
+```
+
+### 4. Anazon Elastic Kubernetes Service (Amazon EKS) Version
+
+You can override the version of the cluster also:
+```bash
+export TF_VAR_eks_version=xxx
+```
+
+
 ## Deploy
 
 Simply run this command to deploy the example

--- a/examples/eks-cluster-with-vpc/main.tf
+++ b/examples/eks-cluster-with-vpc/main.tf
@@ -44,7 +44,7 @@ module "eks_blueprints" {
   source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.13.1"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.24"
+  cluster_version = var.eks_version
 
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnets
@@ -53,7 +53,7 @@ module "eks_blueprints" {
     mg_5 = {
       node_group_name = "managed-ondemand"
       instance_types  = [var.managed_node_instance_type]
-      min_size        = 2
+      min_size        = var.managed_node_min_size
       subnet_ids      = module.vpc.private_subnets
     }
   }

--- a/examples/eks-cluster-with-vpc/main.tf
+++ b/examples/eks-cluster-with-vpc/main.tf
@@ -52,7 +52,7 @@ module "eks_blueprints" {
   managed_node_groups = {
     mg_5 = {
       node_group_name = "managed-ondemand"
-      instance_types  = ["t3.xlarge"]
+      instance_types  = [var.managed_node_instance_type]
       min_size        = 2
       subnet_ids      = module.vpc.private_subnets
     }

--- a/examples/eks-cluster-with-vpc/variables.tf
+++ b/examples/eks-cluster-with-vpc/variables.tf
@@ -12,3 +12,13 @@ variable "managed_node_instance_type" {
   type        = string
   default     = "t3.xlarge"
 }
+variable "managed_node_min_size" {
+  description = "Minumum number of instances in the node group"
+  type        = number
+  default     = 2
+}
+variable "eks_version" {
+  type        = string
+  description = "EKS Cluster version"
+  default     = "1.24"
+}

--- a/examples/eks-cluster-with-vpc/variables.tf
+++ b/examples/eks-cluster-with-vpc/variables.tf
@@ -7,3 +7,8 @@ variable "aws_region" {
   description = "AWS Region"
   type        = string
 }
+variable "managed_node_instance_type" {
+  description = "Instance type for the cluster managed node groups"
+  type        = string
+  default     = "t3.xlarge"
+}


### PR DESCRIPTION
See #89.
Added a variable to change the default instance type for the EKS Cluster


### What does this PR do?

Adds a parameter to the example to override the default instance type for the EKS Cluster.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.


### Motivation

On some regions / scenarios lack of availability of the default instance type will make the deployment of the example fail. This PR allows to easily change to an available instance in the environment.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [N/A] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
- [N/A] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [N/A] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/docs) for this feature
- [x] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

I'll follow up with fixes for tfsec findings on as separate PR.
