### PR TITLE
Update and freeze pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9  # frozen: v4.4.0
     hooks:
       - id: trailing-whitespace
         args: ['--markdown-linebreak-ext=md']
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: ['--allow-missing-credentials']
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: 1d54ea2b9950097568c6a7a2e2bcb6d4b4ebfb61  # frozen: v1.77.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to resolve #92 by updating and freezing the pre-commit hook `rev` to git sha via: 

**--freeze: new in 1.21.0: Store "frozen" hashes in [rev](https://pre-commit.com/#repos-rev) instead of tag names**


### Motivation

Ensure validation/dependency chain is unaltered.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

