### PR TITLE
Update readme and pr template to point to o11y accel repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,9 @@
 ### More
 
 - [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
-- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/examples) to support my PR
+- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR
 - [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
-- [ ] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-eks-blueprints/tree/main/docs) for this feature
+- [ ] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature
 - [ ] Yes, I ran `pre-commit run -a` with this PR
 
 

--- a/README.md
+++ b/README.md
@@ -192,4 +192,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 
 ## License
 
-Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-observability/terraform-aws-eks-blueprints/blob/main/LICENSE).
+Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-observability/terraform-aws-observability-accelerator/blob/main/LICENSE).


### PR DESCRIPTION
### What does this PR do?

This PR resolves #94 by updating the README.md link pointing to the LICENSE file and the PR workflow template pointing at the eks blueprint.

### Motivation

Ensure documentation is relevant and reflects/supports the project.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
