### PR TITLE
Update tflint aws plugin and fix pre-commit to use config file

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ env:
   TERRAFORM_DOCS_VERSION: v0.16.0
   TFSEC_VERSION: v1.22.0
   TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform.d/plugin-cache
-  TFLINT_VERSION: v0.38.1
+  TFLINT_VERSION: v0.44.1
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,19 +20,7 @@ repos:
         exclude: deploy
       - id: terraform_tflint
         args:
-          - '--args=--only=terraform_deprecated_interpolation'
-          - '--args=--only=terraform_deprecated_index'
-          - '--args=--only=terraform_unused_declarations'
-          - '--args=--only=terraform_comment_syntax'
-          - '--args=--only=terraform_documented_outputs'
-          - '--args=--only=terraform_documented_variables'
-          - '--args=--only=terraform_typed_variables'
-          - '--args=--only=terraform_module_pinned_source'
-          - '--args=--only=terraform_naming_convention'
-          - '--args=--only=terraform_required_version'
-          - '--args=--only=terraform_required_providers'
-          - '--args=--only=terraform_standard_module_structure'
-          - '--args=--only=terraform_workspace_remote'
+          - '--args=--config=__GIT_WORKING_DIR__/.tflint.hcl'
       - id: terraform_tfsec
         files: ^examples/ # only scan `examples/*` which are the implementation
         args:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
   enabled = true
-  version = "0.14.0"
+  version = "0.21.1"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to fix #96 by updating the TFLint AWS rules plugin to `0.21.1` and fixing the pre-commit args uses to source from the .tflint.hcl file residing in this repository.

### Motivation

Ensure we're using updated rules and the config file is no longer superfluous. 

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
