### PR TITLE
amp workload teardown

### DIFF
--- a/docs/workloads/managed-prometheus.md
+++ b/docs/workloads/managed-prometheus.md
@@ -96,3 +96,17 @@ Open the CloudWatch console and click `Alarms` > `All Alarms` to review the serv
 In us-east-1 region an alarm is created for billing. This alarm utilizes anomaly detection to detect anomalies in the Estimated Charges billing metric.
 
 <img width="1346" alt="image" src="https://user-images.githubusercontent.com/97046295/197042518-a98d69df-8f53-4a4a-afb8-f424d91da56f.png">
+
+## Destroy resources
+
+If you leave this stack running, you will continue to incur charges. To remove all resources
+created by Terraform, [refresh your Grafana API key](#5-grafana-api-key) and run the command below.
+
+!!! warning
+    Be careful, this command will remove everything created by Terraform. If you wish
+    to keep your Amazon Managed Grafana Dashboards or CloudWatch Alarms. Remove them
+    from your terraform state before running the destroy command.
+
+```bash
+terraform destroy
+```


### PR DESCRIPTION
### What does this PR do?

Adds teardown instructions for managed prometheus workload module.

### Motivation

This one was missing teardown instructions.


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
