### PR TITLE
doc: eks cluster with vpc ref tag

### DIFF
--- a/docs/helpers/new-eks-cluster.md
+++ b/docs/helpers/new-eks-cluster.md
@@ -1,7 +1,7 @@
 # Creating a new Amazon EKS cluster with VPC
 
 !!! note
-    This example is a subset from [this EKS Blueprint example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/eks-cluster-with-new-vpc)
+    This example is a subset from [this EKS Blueprint example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/v4.13.1/examples/eks-cluster-with-new-vpc)
 
 This example deploys the following:
 

--- a/examples/eks-cluster-with-vpc/README.md
+++ b/examples/eks-cluster-with-vpc/README.md
@@ -1,6 +1,6 @@
 # EKS Cluster Deployment with new VPC
 
-Note: This example is a subset from [this EKS Blueprint example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/eks-cluster-with-new-vpc)
+Note: This example is a subset from [this EKS Blueprint example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/v4.13.1/examples/eks-cluster-with-new-vpc)
 
 This example deploys the following Basic EKS Cluster with VPC
 

--- a/examples/existing-cluster-nginx/README.md
+++ b/examples/existing-cluster-nginx/README.md
@@ -46,7 +46,7 @@ Specify the AWS Region where the resources will be deployed. Edit the `terraform
 4. Amazon EKS Cluster
 
 To run this example, you need to provide your EKS cluster name.
-If you don't have a cluster ready, visit [this example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/examples/eks-cluster-with-new-vpc)
+If you don't have a cluster ready, visit [this example](https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/v4.13.1/examples/eks-cluster-with-new-vpc)
 first to create a new one.
 
 Add your cluster name for `eks_cluster_id="..."` to the `terraform.tfvars` or use an environment variable `export TF_VAR_eks_cluster_id=xxx`.


### PR DESCRIPTION
### What does this PR do?

Fix reference link on example docs.  (#120)

### Motivation

Broken reference links not pointing to a valid address. (_broken link_)

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR
- [ ] Yes, I have created another PR for add-ons under [add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) repo (if applicable)
- [ ] Yes, I have updated the [docs](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR


**Note**: Not all the PRs required examples and docs except a new pattern or add-on added.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

#### [Add-ons](https://github.com/aws-samples/eks-blueprints-add-ons) project was checked and no references was found

![image](https://user-images.githubusercontent.com/3392839/219826490-8d20c8c1-9203-46f9-9d1a-6174be649195.png)

