### PR TITLE
Added missing cluster name variable

### DIFF
--- a/examples/eks-cluster-with-vpc/README.md
+++ b/examples/eks-cluster-with-vpc/README.md
@@ -47,7 +47,8 @@ terraform init
 Verify the resources created by this execution
 
 ```sh
-export TF_VAR_aws_region=<ENTER YOUR REGION>   # Select your own region
+export TF_VAR_aws_region=<ENTER YOUR REGION>           # Select your own region
+export TF_VAR_cluster_name=<ENTER YOUR CLUSTER NAME>   # Enter your cluster name
 terraform plan
 ```
 


### PR DESCRIPTION
### What does this PR do?

Added a missing variable definition in the README for eks-cluster-with-vpc example.

### Motivation

<!-- What inspired you to submit this pull request? -->

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
