### PR TITLE
Fix folder path

### DIFF
--- a/docs/helpers/managed-grafana.md
+++ b/docs/helpers/managed-grafana.md
@@ -18,7 +18,7 @@ Center (former SSO). You can extend this example to add SAML.
 
 ```
 git clone https://github.com/aws-observability/terraform-aws-observability-accelerator.git
-cd examples/managed-grafana-workspace
+cd terraform-aws-observability-accelerator/examples/managed-grafana-workspace
 terraform init
 ```
 


### PR DESCRIPTION
Add "terraform-aws-observability-accelerator" to the path


### What does this PR do?

The folder path is wrong and did not include "terraform-aws-observability-accelerator"

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
