### PR TITLE
Publish dashboards only if grafana folder exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_create_dashboard_folder"></a> [create\_dashboard\_folder](#input\_create\_dashboard\_folder) | Boolean flag to enable Amazon Managed Grafana folder and dashboards | `bool` | `false` | no |
-| <a name="input_create_prometheus_data_source"></a> [create\_prometheus\_data\_source](#input\_create\_prometheus\_data\_source) | Boolean flag to enable Amazon Managed Grafana datasource | `bool` | `false` | no |
+| <a name="input_create_dashboard_folder"></a> [create\_dashboard\_folder](#input\_create\_dashboard\_folder) | Boolean flag to enable Amazon Managed Grafana folder and dashboards | `bool` | `true` | no |
+| <a name="input_create_prometheus_data_source"></a> [create\_prometheus\_data\_source](#input\_create\_prometheus\_data\_source) | Boolean flag to enable Amazon Managed Grafana datasource | `bool` | `true` | no |
 | <a name="input_enable_alertmanager"></a> [enable\_alertmanager](#input\_enable\_alertmanager) | Creates Amazon Managed Service for Prometheus AlertManager for all workloads | `bool` | `false` | no |
 | <a name="input_enable_managed_prometheus"></a> [enable\_managed\_prometheus](#input\_enable\_managed\_prometheus) | Creates a new Amazon Managed Service for Prometheus Workspace | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | Grafana API key for the Amazon Managed Grafana workspace | `string` | n/a | yes |
@@ -203,6 +203,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | AWS Region |
+| <a name="output_grafana_dashboard_folder_created"></a> [grafana\_dashboard\_folder\_created](#output\_grafana\_dashboard\_folder\_created) | Boolean value indicating if the module created a dashboard folder in Amazon Managed Grafana |
 | <a name="output_grafana_dashboards_folder_id"></a> [grafana\_dashboards\_folder\_id](#output\_grafana\_dashboards\_folder\_id) | Grafana folder ID for automatic dashboards. Required by workload modules |
 | <a name="output_grafana_prometheus_datasource_test"></a> [grafana\_prometheus\_datasource\_test](#output\_grafana\_prometheus\_datasource\_test) | Grafana save & test URL for Amazon Managed Prometheus workspace |
 | <a name="output_managed_grafana_workspace_endpoint"></a> [managed\_grafana\_workspace\_endpoint](#output\_managed\_grafana\_workspace\_endpoint) | Amazon Managed Grafana workspace endpoint |
@@ -210,6 +211,7 @@ No modules.
 | <a name="output_managed_prometheus_workspace_endpoint"></a> [managed\_prometheus\_workspace\_endpoint](#output\_managed\_prometheus\_workspace\_endpoint) | Amazon Managed Prometheus workspace endpoint |
 | <a name="output_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#output\_managed\_prometheus\_workspace\_id) | Amazon Managed Prometheus workspace ID |
 | <a name="output_managed_prometheus_workspace_region"></a> [managed\_prometheus\_workspace\_region](#output\_managed\_prometheus\_workspace\_region) | Amazon Managed Prometheus workspace region |
+| <a name="output_prometheus_data_source_created"></a> [prometheus\_data\_source\_created](#output\_prometheus\_data\_source\_created) | Boolean value indicating if the module created a prometheus data source in Amazon Managed Grafana |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing

--- a/examples/existing-cluster-java/README.md
+++ b/examples/existing-cluster-java/README.md
@@ -224,6 +224,7 @@ terraform destroy -var-file=terraform.tfvars
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | Name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_enable_dashboards"></a> [enable\_dashboards](#input\_enable\_dashboards) | Enables or disables curated dashboards | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana | `string` | n/a | yes |
 | <a name="input_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#input\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana Workspace ID | `string` | n/a | yes |
 | <a name="input_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#input\_managed\_prometheus\_workspace\_id) | Amazon Managed Service for Prometheus Workspace ID | `string` | `""` | no |

--- a/examples/existing-cluster-java/main.tf
+++ b/examples/existing-cluster-java/main.tf
@@ -71,6 +71,10 @@ module "eks_monitoring" {
 
   eks_cluster_id = var.eks_cluster_id
 
+  # control the publishing of dashboards by specifying the boolean value for the variable 'enable_dashboards', default is 'true'
+  # the intention to publish is overruled depending upon whether grafana dashboard folder is created by the observability accelerator
+  enable_dashboards = module.aws_observability_accelerator.grafana_dashboard_folder_created ? var.enable_dashboards : false
+
   dashboards_folder_id            = module.aws_observability_accelerator.grafana_dashboards_folder_id
   managed_prometheus_workspace_id = module.aws_observability_accelerator.managed_prometheus_workspace_id
 

--- a/examples/existing-cluster-java/variables.tf
+++ b/examples/existing-cluster-java/variables.tf
@@ -2,21 +2,31 @@ variable "eks_cluster_id" {
   description = "Name of the EKS cluster"
   type        = string
 }
+
 variable "aws_region" {
   description = "AWS Region"
   type        = string
 }
+
 variable "managed_prometheus_workspace_id" {
   description = "Amazon Managed Service for Prometheus Workspace ID"
   type        = string
   default     = ""
 }
+
 variable "managed_grafana_workspace_id" {
   description = "Amazon Managed Grafana Workspace ID"
   type        = string
 }
+
 variable "grafana_api_key" {
   description = "API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana"
   type        = string
   sensitive   = true
+}
+
+variable "enable_dashboards" {
+  description = "Enables or disables curated dashboards"
+  type        = bool
+  default     = true
 }

--- a/examples/existing-cluster-nginx/README.md
+++ b/examples/existing-cluster-nginx/README.md
@@ -235,6 +235,7 @@ add this `managed_prometheus_region=xxx` and `managed_prometheus_workspace_id=ws
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
+| <a name="input_enable_dashboards"></a> [enable\_dashboards](#input\_enable\_dashboards) | Enables or disables curated dashboards | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana | `string` | n/a | yes |
 | <a name="input_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#input\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana (AMG) workspace ID | `string` | n/a | yes |
 | <a name="input_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#input\_managed\_prometheus\_workspace\_id) | Amazon Managed Service for Prometheus (AMP) workspace ID | `string` | `""` | no |

--- a/examples/existing-cluster-nginx/main.tf
+++ b/examples/existing-cluster-nginx/main.tf
@@ -67,6 +67,10 @@ module "eks_monitoring" {
 
   eks_cluster_id = var.eks_cluster_id
 
+  # control the publishing of dashboards by specifying the boolean value for the variable 'enable_dashboards', default is 'true'
+  # the intention to publish is overruled depending upon whether grafana dashboard folder is created by the observability accelerator
+  enable_dashboards = module.aws_observability_accelerator.grafana_dashboard_folder_created ? var.enable_dashboards : false
+
   dashboards_folder_id            = module.aws_observability_accelerator.grafana_dashboards_folder_id
   managed_prometheus_workspace_id = module.aws_observability_accelerator.managed_prometheus_workspace_id
 

--- a/examples/existing-cluster-nginx/variables.tf
+++ b/examples/existing-cluster-nginx/variables.tf
@@ -2,21 +2,31 @@ variable "eks_cluster_id" {
   description = "EKS Cluster Id"
   type        = string
 }
+
 variable "aws_region" {
   description = "AWS Region"
   type        = string
 }
+
 variable "managed_prometheus_workspace_id" {
   description = "Amazon Managed Service for Prometheus (AMP) workspace ID"
   type        = string
   default     = ""
 }
+
 variable "managed_grafana_workspace_id" {
   description = "Amazon Managed Grafana (AMG) workspace ID"
   type        = string
 }
+
 variable "grafana_api_key" {
   description = "API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana"
   type        = string
   sensitive   = true
+}
+
+variable "enable_dashboards" {
+  description = "Enables or disables curated dashboards"
+  type        = bool
+  default     = true
 }

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -171,6 +171,7 @@ terraform destroy -var-file=terraform.tfvars
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | Name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_enable_dashboards"></a> [enable\_dashboards](#input\_enable\_dashboards) | Enables or disables curated dashboards | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana | `string` | n/a | yes |
 | <a name="input_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#input\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana Workspace ID | `string` | n/a | yes |
 | <a name="input_managed_prometheus_workspace_id"></a> [managed\_prometheus\_workspace\_id](#input\_managed\_prometheus\_workspace\_id) | Amazon Managed Service for Prometheus Workspace ID | `string` | `""` | no |

--- a/examples/existing-cluster-with-base-and-infra/main.tf
+++ b/examples/existing-cluster-with-base-and-infra/main.tf
@@ -77,6 +77,10 @@ module "eks_monitoring" {
   # reusing existing certificate manager? defaults to true
   enable_cert_manager = true
 
+  # control the publishing of dashboards by specifying the boolean value for the variable 'enable_dashboards', default is 'true'
+  # the intention to publish is overruled depending upon whether grafana dashboard folder is created by the observability accelerator
+  enable_dashboards = module.aws_observability_accelerator.grafana_dashboard_folder_created ? var.enable_dashboards : false
+
   dashboards_folder_id            = module.aws_observability_accelerator.grafana_dashboards_folder_id
   managed_prometheus_workspace_id = module.aws_observability_accelerator.managed_prometheus_workspace_id
 

--- a/examples/existing-cluster-with-base-and-infra/variables.tf
+++ b/examples/existing-cluster-with-base-and-infra/variables.tf
@@ -2,21 +2,31 @@ variable "eks_cluster_id" {
   description = "Name of the EKS cluster"
   type        = string
 }
+
 variable "aws_region" {
   description = "AWS Region"
   type        = string
 }
+
 variable "managed_prometheus_workspace_id" {
   description = "Amazon Managed Service for Prometheus Workspace ID"
   type        = string
   default     = ""
 }
+
 variable "managed_grafana_workspace_id" {
   description = "Amazon Managed Grafana Workspace ID"
   type        = string
 }
+
 variable "grafana_api_key" {
   description = "API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana"
   type        = string
   sensitive   = true
+}
+
+variable "enable_dashboards" {
+  description = "Enables or disables curated dashboards"
+  type        = bool
+  default     = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,13 @@ output "grafana_prometheus_datasource_test" {
   description = "Grafana save & test URL for Amazon Managed Prometheus workspace"
   value       = var.create_prometheus_data_source ? "${local.amg_ws_endpoint}/datasources/edit/${grafana_data_source.amp[0].uid}" : ""
 }
+
+output "grafana_dashboard_folder_created" {
+  description = "Boolean value indicating if the module created a dashboard folder in Amazon Managed Grafana"
+  value       = var.create_dashboard_folder
+}
+
+output "prometheus_data_source_created" {
+  description = "Boolean value indicating if the module created a prometheus data source in Amazon Managed Grafana"
+  value       = var.create_prometheus_data_source
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,13 +41,13 @@ variable "grafana_api_key" {
 variable "create_prometheus_data_source" {
   description = "Boolean flag to enable Amazon Managed Grafana datasource"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "create_dashboard_folder" {
   description = "Boolean flag to enable Amazon Managed Grafana folder and dashboards"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "tags" {


### PR DESCRIPTION
### What does this PR do?

Control the publish of dashboard files only if the folder is created by the observability accelerator 

### Motivation

A bug https://github.com/aws-observability/terraform-aws-observability-accelerator/issues/147

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

None