### PR TITLE
Remove terraform.tfvars from example

### DIFF
--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -43,7 +43,8 @@ To run this example, you need to provide your EKS cluster name.
 If you don't have a cluster ready, visit [this example](../eks-cluster-with-vpc)
 first to create a new one.
 
-Add your cluster name for `eks_cluster_id="..."` to the `terraform.tfvars` or use an environment variable `export TF_VAR_eks_cluster_id=xxx`.
+Add your cluster name for `eks_cluster_id="..."` to a new `terraform.tfvars` file
+or use an environment variable `export TF_VAR_eks_cluster_id=xxx`.
 
 4. Amazon Managed Grafana workspace
 
@@ -170,7 +171,7 @@ terraform destroy -var-file=terraform.tfvars
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | Name of the EKS cluster | `string` | n/a | yes |
+| <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | Name of the EKS cluster | `string` | `"eks-cluster-with-vpc"` | no |
 | <a name="input_enable_dashboards"></a> [enable\_dashboards](#input\_enable\_dashboards) | Enables or disables curated dashboards | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | API key for authorizing the Grafana provider to make changes to Amazon Managed Grafana | `string` | n/a | yes |
 | <a name="input_managed_grafana_workspace_id"></a> [managed\_grafana\_workspace\_id](#input\_managed\_grafana\_workspace\_id) | Amazon Managed Grafana Workspace ID | `string` | n/a | yes |

--- a/examples/existing-cluster-with-base-and-infra/terraform.tfvars
+++ b/examples/existing-cluster-with-base-and-infra/terraform.tfvars
@@ -1,8 +1,0 @@
-# (mandatory) AWS Region where your resources will be located
-aws_region = ""
-
-# (mandatory) EKS Cluster name
-eks_cluster_id = "eks-cluster-with-vpc"
-
-# (optional) Leave it empty for a new workspace to be created
-managed_prometheus_workspace_id = ""

--- a/examples/existing-cluster-with-base-and-infra/variables.tf
+++ b/examples/existing-cluster-with-base-and-infra/variables.tf
@@ -1,6 +1,7 @@
 variable "eks_cluster_id" {
   description = "Name of the EKS cluster"
   type        = string
+  default     = "eks-cluster-with-vpc"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

This change removes `terraform.tfvars` from `examples/existing-cluster-with-base-and-infra`, and uses `variables.tf` for any defaults.


### Motivation

<!-- What inspired you to submit this pull request? -->

When [following the instructions HERE](https://aws-observability.github.io/terraform-aws-observability-accelerator/eks/) it directs the reader to set `TF_VAR_xxxx` environment variables. However, since there is already `terraform.tfvars`, the tfvars file will [take precedent over environment variables per the terraform docs](https://developer.hashicorp.com/terraform/language/values/variables#variable-definition-precedence). This results in `aws_region`, `eks_cluster_id`, and `managed_prometheus_workspace_id` being unable to be set. 


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

Alternatively, we could change the directions on the site. Open to suggestions!
