### PR TITLE
adding multicluster docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Amazon EKS:
       - Infrastructure monitoring: eks/index.md
       - Java/JMX: eks/java.md
+      - Multicluster: eks/multicluster.md
       - Nginx: eks/nginx.md
       - Viewing logs: eks/logs.md
       - Teardown: eks/destroy.md


### PR DESCRIPTION
### What does this PR do?

Adds Docs for multicluster example

<!-- A brief description of the change being made with this pull request. -->

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
