### PR TITLE
Add OTLP receiver for custom metrics

### DIFF
--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -25,14 +25,12 @@ spec:
           fieldPath: "metadata.namespace"
   config: |
     receivers:
-      {{ if .Values.enableTracing }}
       otlp:
         protocols:
           grpc:
             endpoint: {{ .Values.otlpGrpcEndpoint }}
           http:
             endpoint: {{ .Values.otlpHttpEndpoint }}
-      {{ end }}
       prometheus:
         config:
           global:
@@ -1801,7 +1799,7 @@ spec:
       extensions: [pprof, zpages, health_check, sigv4auth]
       pipelines:
         metrics:
-          receivers: [prometheus]
+          receivers: [prometheus, otlp]
           processors: [batch/metrics]
           exporters: [logging, prometheusremotewrite]
         {{ if .Values.enableTracing }}


### PR DESCRIPTION
### What does this PR do?

Support OTLP receiver for custom metrics

### Motivation

Only prometheus metrics are being collected from custom applications. This adds an otlp receiver for metrics into Managed Service for Prometheus

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
