### PR TITLE
Fix: collector failing to scrape targets

### DIFF
--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -36,9 +36,6 @@ spec:
           global:
             scrape_interval: {{ .Values.globalScrapeInterval }}
             scrape_timeout: {{ .Values.globalScrapeTimeout }}
-            external_labels:
-              cluster: {{ .Values.ekscluster }}
-              region: {{ .Values.region }}
           scrape_configs:
             - job_name: 'kubernetes-kubelet'
               scrape_interval: {{ .Values.globalScrapeInterval }}
@@ -1775,6 +1772,8 @@ spec:
         endpoint: {{ .Values.ampurl }}
         auth:
           authenticator: sigv4auth
+        resource_to_telemetry_conversion:
+          enabled: true
       logging:
         loglevel: warn
     extensions:
@@ -1790,6 +1789,17 @@ spec:
       batch/metrics:
         timeout: 30s
         send_batch_size: 500
+      attributes/metrics:
+        actions:
+          - key: cluster
+            action: upsert
+            value: {{ .Values.ekscluster }}
+          - key: region
+            action: upsert
+            value: {{ .Values.region }}
+          - key: account_id
+            action: upsert
+            value: {{ .Values.accountId }}
     {{ if .Values.enableTracing }}
       batch/traces:
         timeout: {{ .Values.tracingTimeout }}
@@ -1800,7 +1810,7 @@ spec:
       pipelines:
         metrics:
           receivers: [prometheus, otlp]
-          processors: [batch/metrics]
+          processors: [batch/metrics, attributes/metrics]
           exporters: [logging, prometheusremotewrite]
         {{ if .Values.enableTracing }}
         traces:

--- a/modules/eks-monitoring/variables.tf
+++ b/modules/eks-monitoring/variables.tf
@@ -210,8 +210,8 @@ variable "tracing_config" {
   })
 
   default = {
-    otlp_grpc_endpoint = "0.0.0.0:4317"
-    otlp_http_endpoint = "0.0.0.0:4318"
+    otlp_grpc_endpoint = "localhost:4317"
+    otlp_http_endpoint = "localhost:4318"
     send_batch_size    = 50
     timeout            = "30s"
   }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Proposal for https://github.com/aws-observability/terraform-aws-observability-accelerator/issues/171

Suspecting external labels conflicts with scrape config, using attributes processor and `resourcetotelemetry` to enforce those labels on all metrics, post scraping


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
