### PR TITLE
K8s operator metrics

### DIFF
--- a/modules/eks-monitoring/otel-config/Chart.yaml
+++ b/modules/eks-monitoring/otel-config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opentelemetry
 description: A Helm chart to install otel operator
 type: application
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.6.0
+appVersion: 0.6.0

--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -83,6 +83,28 @@ spec:
                 regex: $K8S_NODE_NAME
                 source_labels: [__meta_kubernetes_node_name]
               {{ end }}
+            - job_name: 'kube-admin'
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: node
+              relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
+              - target_label: __address__
+                replacement: kubernetes.default.svc.cluster.local:443
+              {{ if .Values.enableTracing }}
+              - action: keep
+                regex: $K8S_NODE_NAME
+                source_labels: [__meta_kubernetes_node_name]
+              {{ end }}
+              metric_relabel_configs:
+              - action: keep
+                source_labels: [__name__]
+                regex: 'apiserver_(request_duration_seconds|storage_list_duration_seconds|admission_controller_admission_duration_seconds|flowcontrol_request_wait_duration_seconds).*|apiserver_(admission_webhook_fail_open_count|tls_handshake_errors_total|request_total)|rest_client_request_duration_seconds.*|rest_client_requests_total|etcd_(request_duration_seconds|db_total_size_in_bytes).*'
             - job_name: serviceMonitor/default/kube-prometheus-stack-prometheus-node-exporter/0
               honor_timestamps: true
               scrape_interval: {{ .Values.globalScrapeInterval }}
@@ -1100,117 +1122,6 @@ spec:
                     own_namespace: false
                     names:
                     - kube-system
-            - job_name: serviceMonitor/default/kube-prometheus-stack-kube-etcd/0
-              honor_timestamps: true
-              scrape_interval: {{ .Values.globalScrapeInterval }}
-              scrape_timeout: {{ .Values.globalScrapeTimeout }}
-              scheme: http
-              authorization:
-                type: Bearer
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              follow_redirects: true
-              enable_http2: true
-              relabel_configs:
-              - source_labels: [job]
-                separator: ;
-                regex: (.*)
-                target_label: __tmp_prometheus_job_name
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
-                separator: ;
-                regex: (kube-prometheus-stack-kube-etcd);true
-                replacement: $$1
-                action: keep
-              - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
-                separator: ;
-                regex: (kube-prometheus-stack);true
-                replacement: $$1
-                action: keep
-              - source_labels: [__meta_kubernetes_endpoint_port_name]
-                separator: ;
-                regex: http-metrics
-                replacement: $$1
-                action: keep
-              - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                separator: ;
-                regex: Node;(.*)
-                target_label: node
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                separator: ;
-                regex: Pod;(.*)
-                target_label: pod
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_namespace]
-                separator: ;
-                regex: (.*)
-                target_label: namespace
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_name]
-                separator: ;
-                regex: (.*)
-                target_label: service
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_pod_name]
-                separator: ;
-                regex: (.*)
-                target_label: pod
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_pod_container_name]
-                separator: ;
-                regex: (.*)
-                target_label: container
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_name]
-                separator: ;
-                regex: (.*)
-                target_label: job
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_label_jobLabel]
-                separator: ;
-                regex: (.+)
-                target_label: job
-                replacement: $$1
-                action: replace
-              - separator: ;
-                regex: (.*)
-                target_label: endpoint
-                replacement: http-metrics
-                action: replace
-              - source_labels: [__address__]
-                separator: ;
-                regex: (.*)
-                modulus: 1
-                target_label: __tmp_hash
-                replacement: $$1
-                action: hashmod
-              - source_labels: [__tmp_hash]
-                separator: ;
-                regex: "0"
-                replacement: $$1
-                action: keep
-              {{ if .Values.enableTracing }}
-              - action: keep
-                regex: $K8S_NODE_NAME
-                source_labels: [__meta_kubernetes_endpoint_node_name]
-              {{ end }}
-              kubernetes_sd_configs:
-                - role: endpoints
-                  kubeconfig_file: ""
-                  follow_redirects: true
-                  enable_http2: true
-                  namespaces:
-                    own_namespace: false
-                    names:
-                    - kube-system
             - job_name: serviceMonitor/default/kube-prometheus-stack-kube-controller-manager/0
               honor_timestamps: true
               scrape_interval: {{ .Values.globalScrapeInterval }}
@@ -1431,115 +1342,6 @@ spec:
                     own_namespace: false
                     names:
                     - kube-system
-            - job_name: serviceMonitor/default/kube-prometheus-stack-apiserver/0
-              honor_timestamps: true
-              scrape_interval: {{ .Values.globalScrapeInterval }}
-              scrape_timeout: {{ .Values.globalScrapeTimeout }}
-              scheme: https
-              authorization:
-                type: Bearer
-                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-              tls_config:
-                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-                server_name: kubernetes
-              follow_redirects: true
-              enable_http2: true
-              relabel_configs:
-              - source_labels: [job]
-                separator: ;
-                regex: (.*)
-                target_label: __tmp_prometheus_job_name
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_label_component, __meta_kubernetes_service_labelpresent_component]
-                separator: ;
-                regex: (kubernetes);true
-                replacement: $$1
-                action: keep
-              - source_labels: [__meta_kubernetes_endpoint_port_name]
-                separator: ;
-                regex: https
-                replacement: $$1
-                action: keep
-              - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                separator: ;
-                regex: Node;(.*)
-                target_label: node
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
-                separator: ;
-                regex: Pod;(.*)
-                target_label: pod
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_namespace]
-                separator: ;
-                regex: (.*)
-                target_label: namespace
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_name]
-                separator: ;
-                regex: (.*)
-                target_label: service
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_pod_name]
-                separator: ;
-                regex: (.*)
-                target_label: pod
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_pod_container_name]
-                separator: ;
-                regex: (.*)
-                target_label: container
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_name]
-                separator: ;
-                regex: (.*)
-                target_label: job
-                replacement: $$1
-                action: replace
-              - source_labels: [__meta_kubernetes_service_label_component]
-                separator: ;
-                regex: (.+)
-                target_label: job
-                replacement: $$1
-                action: replace
-              - separator: ;
-                regex: (.*)
-                target_label: endpoint
-                replacement: https
-                action: replace
-              - source_labels: [__address__]
-                separator: ;
-                regex: (.*)
-                modulus: 1
-                target_label: __tmp_hash
-                replacement: $$1
-                action: hashmod
-              - source_labels: [__tmp_hash]
-                separator: ;
-                regex: "0"
-                replacement: $$1
-                action: keep
-              {{ if .Values.enableTracing }}
-              - action: keep
-                regex: $K8S_NODE_NAME
-                source_labels: [__meta_kubernetes_endpoint_node_name]
-              {{ end }}
-              kubernetes_sd_configs:
-                - role: endpoints
-                  kubeconfig_file: ""
-                  follow_redirects: true
-                  enable_http2: true
-                  namespaces:
-                    own_namespace: false
-                    names:
-                    - default
             - job_name: serviceMonitor/default/kube-prometheus-stack-alertmanager/0
               honor_timestamps: true
               scrape_interval: {{ .Values.globalScrapeInterval }}

--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -92,8 +92,6 @@ spec:
               kubernetes_sd_configs:
               - role: node
               relabel_configs:
-              - action: labelmap
-                regex: __meta_kubernetes_node_label_(.+)
               - target_label: __address__
                 replacement: kubernetes.default.svc.cluster.local:443
               {{ if .Values.enableTracing }}


### PR DESCRIPTION
### What does this PR do?

This adds a few metrics defined here https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/ for an admin/operator dashboard. 
<img width="1702" alt="image" src="https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/a9322fac-fc58-4e38-9fca-d019d9a24ded">



As we can see in the screenshot below before and after received samples count is quite similar, making sure to add only those metrics. A cleaning of dead scrape target was done as well.
<img width="1046" alt="image" src="https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/655d442c-9462-4a50-830e-f4f0eba5c661">

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
