### PR TITLE
Fluentbit improvements 

### DIFF
--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/README.md
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/README.md
@@ -42,6 +42,7 @@ See this [Helm Chart](https://github.com/aws/eks-charts/tree/master/stable/aws-f
 | <a name="input_helm_config"></a> [helm\_config](#input\_helm\_config) | Helm provider config aws\_for\_fluent\_bit. | `any` | `{}` | no |
 | <a name="input_irsa_policies"></a> [irsa\_policies](#input\_irsa\_policies) | Additional IAM policies for a IAM role for service accounts | `list(string)` | `[]` | no |
 | <a name="input_manage_via_gitops"></a> [manage\_via\_gitops](#input\_manage\_via\_gitops) | Determines if the add-on should be managed via GitOps. | `bool` | `false` | no |
+| <a name="input_refresh_interval"></a> [refresh\_interval](#input\_refresh\_interval) | FluentBit input refresh interval | `number` | `60` | no |
 
 ## Outputs
 

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/locals.tf
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/locals.tf
@@ -33,6 +33,7 @@ locals {
     aws_region         = var.addon_context.aws_region_name
     cluster_name       = var.addon_context.eks_cluster_id
     log_retention_days = var.cw_log_retention_days
+    refresh_interval   = var.refresh_interval
     service_account    = local.service_account
   })]
 

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/locals.tf
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/locals.tf
@@ -18,7 +18,7 @@ locals {
     name        = local.name
     chart       = local.name
     repository  = "https://aws.github.io/eks-charts"
-    version     = "0.1.24"
+    version     = "0.1.27"
     namespace   = local.name
     values      = local.default_helm_values
     description = "aws-for-fluentbit Helm Chart deployment configuration"

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
@@ -26,5 +26,5 @@ additionalInputs: |
       DB                /var/log/flb_kube.db
       Mem_Buf_Limit     5MB
       Skip_Long_Lines   On
-      Refresh_Interval  10
+      Refresh_Interval  ${refresh_interval}
       multiline.parser  cri, docker, go, java, python

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
@@ -14,3 +14,17 @@ cloudWatchLogs:
   logStreamTemplate: $kubernetes['container_name'].$kubernetes['pod_name']
   logKey: log
   logRetentionDays: ${log_retention_days}
+
+input:
+  enabled: false
+
+additionalInputs: |
+  [INPUT]
+      Name              tail
+      Tag               kube.*
+      Path              /var/log/containers/*.log
+      DB                /var/log/flb_kube.db
+      Mem_Buf_Limit     5MB
+      Skip_Long_Lines   On
+      Refresh_Interval  10
+      multiline.parser  cri, docker, go, java, python

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/values.yaml
@@ -12,5 +12,5 @@ cloudWatchLogs:
   logGroupName: /aws/eks/observability-accelerator/workloads
   logGroupTemplate: /aws/eks/observability-accelerator/${cluster_name}/$kubernetes['namespace_name']
   logStreamTemplate: $kubernetes['container_name'].$kubernetes['pod_name']
-  log_key: log
+  logKey: log
   logRetentionDays: ${log_retention_days}

--- a/modules/eks-monitoring/add-ons/aws-for-fluentbit/variables.tf
+++ b/modules/eks-monitoring/add-ons/aws-for-fluentbit/variables.tf
@@ -10,6 +10,13 @@ variable "cw_log_retention_days" {
   default     = 90
 }
 
+variable "refresh_interval" {
+  description = "FluentBit input refresh interval"
+  type        = number
+  default     = 60
+}
+
+
 variable "manage_via_gitops" {
   type        = bool
   description = "Determines if the add-on should be managed via GitOps."


### PR DESCRIPTION
### What does this PR do?

Cleans up log format for logs collected by FluentBit

Before:
```json
{
    "log": "2023-06-23T12:25:48.21020769Z stderr F 2023-06-23T12:25:48.210Z\tinfo\tMetricsExporter\t{\"kind\": \"exporter\", \"data_type\": \"metrics\", \"name\": \"logging\", \"resource metrics\": 1, \"metrics\": 336, \"data points\": 866}",
    "kubernetes": {
        "pod_name": "adot-collector-67ddcff9d8-phwpj",
        "namespace_name": "adot-collector-kubeprometheus",
        "pod_id": "a6265b55-e0f1-446d-94a3-36fe02c2d05f",
        "labels": {
            "app.kubernetes.io/component": "opentelemetry-collector",
            "app.kubernetes.io/instance": "adot-collector-kubeprometheus.adot",
            "app.kubernetes.io/managed-by": "opentelemetry-operator",
            "app.kubernetes.io/name": "adot-collector",
            "app.kubernetes.io/part-of": "opentelemetry",
            "app.kubernetes.io/version": "latest",
            "pod-template-hash": "67ddcff9d8"
        },
        "annotations": {
            "opentelemetry-operator-config/sha256": "86cffa06e194ca52e19c880e5e4dd8e5f0da8275e407a9c93d91cae1254fe772"
        },
        "host": "ip-10-0-10-151.eu-central-1.compute.internal",
        "container_name": "otc-container",
        "docker_id": "0561f678444c7ba55acc3e47735c620ca81c907a1708fe75f39794a784465e4b",
        "container_image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.29.1"
    }
}
```

After:
```
2023-07-07T14:45:09.178Z	info	MetricsExporter	{
    "kind": "exporter",
    "data_type": "metrics",
    "name": "logging",
    "resource metrics": 1,
    "metrics": 16,
    "data points": 1206
}
```

### Motivation

- Removes  stdout infos and k8s log attributes
- "Attempts" at parsing multi log line from fluentBit native multiline parsers


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.