### PR TITLE
Extend configuration for customMetrics

### DIFF
--- a/docs/eks/index.md
+++ b/docs/eks/index.md
@@ -170,11 +170,14 @@ In the module `module "workloads_infra" {` add the following config (make sure t
 enable_custom_metrics = true
 
 custom_metrics_config = {
-    # list of applications ports (example)
-    ports = [8000, 8080]
-
-    # list of series prefixes you want to discard from ingestion
-    dropped_series_prefixes = ["go_gcc"]
+    custom_app_1 = {
+        enableBasicAuth       = true
+        path                  = "/metrics"
+        basicAuthUsername     = "username"
+        basicAuthPassword     = "password"
+        ports                 = ".*:(8080)$"
+        droppedSeriesPrefixes = "(unspecified.*)$"
+    }
 }
 ```
 

--- a/modules/eks-monitoring/README.md
+++ b/modules/eks-monitoring/README.md
@@ -67,7 +67,7 @@ See examples using this Terraform modules in the **Amazon EKS** section of [this
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_adot_loglevel"></a> [adot\_loglevel](#input\_adot\_loglevel) | Verbosity level for ADOT collector logs | `string` | `"warn"` | no |
-| <a name="input_custom_metrics_config"></a> [custom\_metrics\_config](#input\_custom\_metrics\_config) | Configuration object to enable custom metrics collection | <pre>object({<br>    ports = list(number)<br>    # paths = optional(list(string), ["/metrics"])<br>    # list of samples to be dropped by label prefix, ex: go_ -> discards go_.*<br>    dropped_series_prefixes = list(string)<br>  })</pre> | <pre>{<br>  "dropped_series_prefixes": [<br>    "unspecified"<br>  ],<br>  "ports": []<br>}</pre> | no |
+| <a name="input_custom_metrics_config"></a> [custom\_metrics\_config](#input\_custom\_metrics\_config) | Configuration object to enable custom metrics collection | <pre>map(object({<br>    enableBasicAuth       = bool<br>    path                  = string<br>    basicAuthUsername     = string<br>    basicAuthPassword     = string<br>    ports                 = string<br>    droppedSeriesPrefixes = string<br>  }))</pre> | `null` | no |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | EKS Cluster Id | `string` | n/a | yes |
 | <a name="input_enable_alerting_rules"></a> [enable\_alerting\_rules](#input\_enable\_alerting\_rules) | Enables or disables Managed Prometheus alerting rules | `bool` | `true` | no |
 | <a name="input_enable_amazon_eks_adot"></a> [enable\_amazon\_eks\_adot](#input\_enable\_amazon\_eks\_adot) | Enables the ADOT Operator on the EKS Cluster | `bool` | `true` | no |

--- a/modules/eks-monitoring/main.tf
+++ b/modules/eks-monitoring/main.tf
@@ -138,12 +138,8 @@ module "helm_addon" {
       value = var.enable_custom_metrics
     },
     {
-      name  = "customMetricsPorts"
-      value = format(".*:(%s)$", join("|", var.custom_metrics_config.ports))
-    },
-    {
-      name  = "customMetricsDroppedSeriesPrefixes"
-      value = format("(%s.*)$", join(".*|", var.custom_metrics_config.dropped_series_prefixes))
+      name  = "custom_metrics"
+      value = yamlencode(var.custom_metrics_config)
     },
     {
       name  = "enableJava"

--- a/modules/eks-monitoring/otel-config/Chart.yaml
+++ b/modules/eks-monitoring/otel-config/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opentelemetry
 description: A Helm chart to install otel operator
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.7.0
+appVersion: 0.7.0

--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -1464,13 +1464,21 @@ spec:
                   regex: $K8S_NODE_NAME
                   source_labels: [__meta_kubernetes_endpoint_node_name]
                 {{ end }}
-            - job_name: "custom-metrics"
+            {{ if .Values.enableCustomMetrics }}
+            {{- range $k, $v := fromYaml .Values.customMetrics }}
+            - job_name: "{{ $k }}"
               kubernetes_sd_configs:
                 - role: pod
+              metrics_path: '{{ $v.path }}'
+              {{ if $v.enableBasicAuth }}
+              basic_auth:
+                username: '{{ $v.basicAuthUsername }}'
+                password: '{{ $v.basicAuthPassword }}'
+              {{ end }}
               relabel_configs:
                 - source_labels: [ __address__ ]
                   action: keep
-                  regex: '{{ .Values.customMetricsPorts }}'
+                  regex: '{{ $v.ports }}'
                 - action: replace
                   source_labels: [__meta_kubernetes_pod_node_name]
                   target_label: nodename
@@ -1486,16 +1494,17 @@ spec:
                 - action: replace
                   source_labels: [__meta_kubernetes_pod_controller_kind]
                   target_label: pod_controller_kind
-                {{ if .Values.enableTracing }}
+                {{ if $.Values.enableTracing }}
                 - action: keep
                   regex: $K8S_NODE_NAME
                   source_labels: [__meta_kubernetes_pod_node_name]
                 {{ end }}
               metric_relabel_configs:
                 - source_labels: [ __name__ ]
-                  regex: '{{ .Values.customMetricsDroppedSeriesPrefixes }}'
+                  regex: '{{ $v.droppedSeriesPrefixes }}'
                   action: drop
-
+            {{- end }}
+            {{ end }}
             {{ if .Values.enableJava }}
             - job_name: 'kubernetes-java-jmx'
               sample_limit: {{ .Values.javaScrapeSampleLimit }}

--- a/modules/eks-monitoring/otel-config/values.yaml
+++ b/modules/eks-monitoring/otel-config/values.yaml
@@ -13,8 +13,7 @@ tracingTimeout: ${tracing_timeout}
 tracingSendBatchSize: ${tracing_send_batch_size}
 
 enableCustomMetrics: ${enable_custom_metrics}
-customMetricsPorts: ${custom_metrics_ports}
-customMetricsDroppedSeriesPrefixes: ${custom_metrics_dropped_series_prefixes}
+customMetrics: ${custom_metrics}
 
 enableJava: ${enable_java}
 javaScrapeSampleLimit: ${java_scrape_sample_limit}

--- a/modules/eks-monitoring/variables.tf
+++ b/modules/eks-monitoring/variables.tf
@@ -232,17 +232,16 @@ variable "enable_custom_metrics" {
 
 variable "custom_metrics_config" {
   description = "Configuration object to enable custom metrics collection"
-  type = object({
-    ports = list(number)
-    # paths = optional(list(string), ["/metrics"])
-    # list of samples to be dropped by label prefix, ex: go_ -> discards go_.*
-    dropped_series_prefixes = list(string)
-  })
+  type = map(object({
+    enableBasicAuth       = bool
+    path                  = string
+    basicAuthUsername     = string
+    basicAuthPassword     = string
+    ports                 = string
+    droppedSeriesPrefixes = string
+  }))
 
-  default = {
-    ports                   = []
-    dropped_series_prefixes = ["unspecified"]
-  }
+  default = null
 }
 
 variable "enable_java" {


### PR DESCRIPTION
### What does this PR do?

As explained here #196 , the aim is to give you the option of adding more customised metrics configurations.



### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
