### PR TITLE
Lint: Skip flaky module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
         exclude: deploy
       - id: terraform_tflint
         args:
+          - '--args=--filter=modules/eks-container-insights'
           - '--args=--config=__GIT_WORKING_DIR__/.tflint.hcl'
       - id: terraform_tfsec
         files: ^examples/ # only scan `examples/*` which are the implementation


### PR DESCRIPTION
### What does this PR do?

Tflint bugs with one of the modules `eks-container-insights` with `terraform_unused_declarations`

<!-- A brief description of the change being made with this pull request. -->

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
