### PR TITLE
chore: Cleanup docs assets

### DIFF
--- a/docs/adothealth/index.md
+++ b/docs/adothealth/index.md
@@ -7,7 +7,8 @@ The OpenTelemetry collector produces metrics to monitor the entire pipeline. In 
 
 Below diagram shows an example data flow and the components in an ADOT collector:
 
-![ADOTCollectorComponents](https://github.com/RAMathews/terraform-aws-observability-accelerator/assets/114662591/1db25d84-c1ca-4468-bb0d-42c8bafd1942)
+![ADOTCollectorComponents](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/71a4a53d-f9fd-45b0-81cb-e060d2b3915b)
+
 
 In this dashboard, there are five sections. Each section has [metrics](https://aws-observability.github.io/observability-best-practices/guides/operational/adot-at-scale/operating-adot-collector/#collecting-health-metrics-from-the-collector) relevant to the various [components](https://opentelemetry.io/docs/demo/collector-data-flow-dashboard/#data-flow-overview) of the AWS Distro for OpenTelemetry (ADOT) collector :
 
@@ -17,22 +18,24 @@ Shows the receiver’s accepted and refused rate/count of spans and metric point
 ### Processors
 Shows the accepted and refused rate/count of spans and metric points pushed into next component in the pipeline. The batch metrics can help to understand how often metrics are sent to exporter and the batch size.
 
-![receivers_processors](https://github.com/RAMathews/terraform-aws-observability-accelerator/assets/114662591/9a2edc27-9472-4a58-a244-d69f2bc7f41f)
+![receivers_processors](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/34bfb881-1004-480f-8e0e-4ded10463d31)
+
 
 ### Exporters
 Shows the exporter’s accepted and refused rate/count of spans and metric points that are pushed to any of the destinations. It also shows the size and capacity of the retry queue. These metrics can be used to understand if the collector is having issues in sending trace or metric data to the destination configured.
 
-![exporters](https://github.com/RAMathews/terraform-aws-observability-accelerator/assets/114662591/77e20ac5-64bb-42ca-9db6-4d13ca7b27de)
+![exporters](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/0bceaa32-a52c-4e23-9b6f-8b208e337f4f)
+
 
 ### Collectors
 Shows the collector’s operational metrics (Memory, CPU, uptime). This can be used to understand how much resources the collector is consuming.
 
-![collectors](https://github.com/RAMathews/terraform-aws-observability-accelerator/assets/114662591/25151edd-6132-479a-9331-71aa69a91d5e)
+![collectors](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/fc68d2f4-d6a1-4d34-ac05-78e57310c28e)
 
 ### Data Flow
 Shows the metrics and spans data flow through the collector’s components.
 
-![dataflow](https://github.com/RAMathews/terraform-aws-observability-accelerator/assets/114662591/61fe684d-8ed3-4645-9210-f16158442b7d)
+![dataflow](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/ffcdafca-5718-4d19-889d-b9503a295679)
 
 !!!note
     To read more about the metrics and the dashboard used, visit the upstream documentation [here](https://opentelemetry.io/docs/demo/collector-data-flow-dashboard/).

--- a/docs/container-insights/eks.md
+++ b/docs/container-insights/eks.md
@@ -46,8 +46,7 @@ terraform apply
 
 After apply, open your Amazon CloudWatch console in the same region as your EKS cluster, then from the left hand side choose `Insights -> Container Insights`, there choose the `Performance montoring` from the drop down, choose the `cluster name` and you will see the metrics shown on the dashboard:
 
-
-<img width="1423" alt="Screenshot 2023-08-08 at 1.15.14 PM" src="https://github.com/RJrocks/terraform-aws-observability-accelerator/assets/5756583/4c5e4ed3-2e1f-4d41-b568-01976fbfd303">
+![image](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/c5b9b685-5894-4350-b68a-ca86d1128f6f)
 
 
 ## Cleanup

--- a/docs/eks/eks-apiserver.md
+++ b/docs/eks/eks-apiserver.md
@@ -1,23 +1,25 @@
-# Monitoring EKS API server
+# Monitoring Amazon EKS API server
 
-AWS Distro of OpenTelemetry enables EKS API server monitoring by default and provides three Grafana dashboards:
+AWS Distro for OpenTelemetry (ADOT) enables Amazon EKS API server monitoring by default and provides three Grafana dashboards:
 
 ## Kube-apiserver (basic)
 
-The basic dashboard shows metrics recommended in [EKS Best Practices Guides - Monitor Control Plane Metrics](https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics) and provides request rate and latency for API server, latency for ETCD server and overall workqueue sercice time and latency. It allows a drill-down per API server.
+The basic dashboard shows metrics recommended in [EKS Best Practices Guides - Monitor Control Plane Metrics](https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics) and provides request rate and latency for API server, latency for ETCD server and overall workqueue service time and latency. It allows a drill-down per API server.
 
-![image](https://github.com/youwalther65/terraform-aws-observability-accelerator/assets/29410195/9dcf2583-6630-4d3c-911d-8ca48ae2d26f)
+![API server basic dashboard](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/d4ba74c4-7530-4037-b373-fa68986cabfc)
+
 
 ## Kube-apiserver (advanced)
 
-The advanced dashboard is derived from kube-prometheus-stack "Kubernetes / API server" dashboard and provides a detailed metrics drill-down for example per READ and WRITE operations per  component (like deployments, configmaps etc.).
+The advanced dashboard is derived from kube-prometheus-stack `Kubernetes / API server` dashboard and provides a detailed metrics drill-down for example per READ and WRITE operations per component (like deployments, configmaps etc.).
 
-![image](https://github.com/youwalther65/terraform-aws-observability-accelerator/assets/29410195/e76a6357-461f-416d-8bf0-5b7777848bea)
+![API server advanced dashboard](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/8d614a6d-38c5-47bc-acfc-6cea4bc1f070)
+
 
 ## Kube-apiserver (troubleshooting)
 
-This dashboards can be used to troubleshoot API server problems like latency, errors etc.
+This dashboard can be used to troubleshoot API server problems like latency, errors etc.
 
 A detailed description for usage and background information regarding the dashboard can be found in AWS Containers blog post [Troubleshooting Amazon EKS API servers with Prometheus](https://aws.amazon.com/blogs/containers/troubleshooting-amazon-eks-api-servers-with-prometheus/).
 
-![image](https://github.com/youwalther65/terraform-aws-observability-accelerator/assets/29410195/921d3453-dcda-4d8a-8223-7c02f1f08ee2)
+![API server troubleshooting dashboard](https://github.com/aws-observability/terraform-aws-observability-accelerator/assets/10175027/687b5fac-8ae4-4a49-924c-6b3d708b9569)


### PR DESCRIPTION
### What does this PR do?

Some of the docs assets live under contributors' forks. This PR move them to upstream


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
