### PR TITLE
Added updated example for traffic generator

### DIFF
--- a/docs/eks/nginx.md
+++ b/docs/eks/nginx.md
@@ -103,7 +103,7 @@ EXTERNAL_IP=your-nginx-controller-external-ip
 
 ```sh
 SAMPLE_TRAFFIC_NAMESPACE=nginx-sample-traffic
-curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml |
+curl https://raw.githubusercontent.com/aws-observability/terraform-aws-observability-accelerator/main/examples/existing-cluster-nginx/sample_traffic/nginx-traffic-sample.yaml |
 sed "s/{{external_ip}}/$EXTERNAL_IP/g" |
 sed "s/{{namespace}}/$SAMPLE_TRAFFIC_NAMESPACE/g" |
 kubectl apply -f -

--- a/examples/existing-cluster-nginx/README.md
+++ b/examples/existing-cluster-nginx/README.md
@@ -160,7 +160,7 @@ EXTERNAL_IP=your-nginx-controller-external-ip
 
 ```sh
 SAMPLE_TRAFFIC_NAMESPACE=nginx-sample-traffic
-curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml |
+cat ./sample_traffic/nginx-traffic-sample.yaml |
 sed "s/{{external_ip}}/$EXTERNAL_IP/g" |
 sed "s/{{namespace}}/$SAMPLE_TRAFFIC_NAMESPACE/g" |
 kubectl apply -f -

--- a/examples/existing-cluster-nginx/sample_traffic/nginix-traffic-sample.yaml
+++ b/examples/existing-cluster-nginx/sample_traffic/nginix-traffic-sample.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+  labels:
+    name: {{namespace}}
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: banana-app
+  namespace: {{namespace}}
+  labels:
+    app: banana
+spec:
+  containers:
+    - name: banana-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=banana"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: banana-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: banana
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: apple-app
+  namespace: {{namespace}}
+  labels:
+    app: apple
+spec:
+  containers:
+    - name: apple-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=apple"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: apple-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: apple
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-nginx-demo
+  namespace: {{namespace}}
+spec:
+  rules:
+  - host: {{external_ip}}
+    http:
+      paths:
+        - path: /apple
+          pathType: Prefix
+          backend:
+            service:
+              name: apple-service
+              port: 
+                number: 5678
+        - path: /banana
+          pathType: Prefix
+          backend:
+            service:
+              name: banana-service
+              port: 
+                number: 5678
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: traffic-generator
+  namespace: {{namespace}}
+spec:
+  containers:
+    - name: traffic-generator
+      image: ellerbrock/alpine-bash-curl-ssl
+      command: ["/bin/bash"]
+      args: ["-c", "while :; do curl http://{{external_ip}}/apple > /dev/null 2>&1; curl http://{{external_ip}}/banana > /dev/null 2>&1; sleep 1; done"]
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi

--- a/examples/existing-cluster-nginx/sample_traffic/nginix-traffic-sample.yaml
+++ b/examples/existing-cluster-nginx/sample_traffic/nginix-traffic-sample.yaml
@@ -92,14 +92,14 @@ spec:
           backend:
             service:
               name: apple-service
-              port: 
+              port:
                 number: 5678
         - path: /banana
           pathType: Prefix
           backend:
             service:
               name: banana-service
-              port: 
+              port:
                 number: 5678
 
 ---


### PR DESCRIPTION
### What does this PR do?

Adds sample NGINX traffic generator deployment to the repository.

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.

Fix #231

### Motivation

The current [file](https://github.com/aws-samples/amazon-cloudwatch-container-insights/blob/main/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml) used for the examples uses a deprecated API, adding the example file in the repository will allow this deployment to succeed.


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [N/A ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->

```
❯ kubectl get ingress --namespace nginx-sample-traffic
NAME                 CLASS    HOSTS                                                                   ADDRESS   PORTS   AGE
ingress-nginx-demo   <none>   ****masked****.us-east-1.elb.amazonaws.com             80      25m
```
