### PR TITLE
CI: Skip cross account testing

### DIFF
--- a/.github/workflows/plan-examples.py
+++ b/.github/workflows/plan-examples.py
@@ -9,7 +9,7 @@ def get_examples():
     returning a string formatted json array of the example directories minus those that are excluded
     """
     exclude = {
-        '',  # Add examples here to exclude from terraform plan
+        'examples/eks-cross-account-with-central-amp',  # Add examples here to exclude from terraform plan
     }
 
     projects = {


### PR DESCRIPTION
### What does this PR do?

As we don't have a cross account setup for tests, this skips the x account example and fix the test badge