### PR TITLE
fix: eks 1.28 migrate kubectl provider to alekc repo

### DIFF
--- a/examples/eks-cluster-with-vpc/versions.tf
+++ b/examples/eks-cluster-with-vpc/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.20"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/eks-container-insights/README.md
+++ b/examples/eks-container-insights/README.md
@@ -14,7 +14,7 @@ under **Amazon CloudWatch Container Insights**
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/examples/eks-container-insights/versions.tf
+++ b/examples/eks-container-insights/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/eks-cross-account-with-central-amp/versions.tf
+++ b/examples/eks-cross-account-with-central-amp/versions.tf
@@ -18,8 +18,8 @@ terraform {
       configuration_aliases = [helm.eks_cluster_one, helm.eks_cluster_two]
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
   }
 }

--- a/examples/eks-istio/README.md
+++ b/examples/eks-istio/README.md
@@ -10,7 +10,7 @@ View the full documentation for this example [here](https://aws-observability.gi
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/examples/eks-istio/versions.tf
+++ b/examples/eks-istio/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/eks-multicluster/versions.tf
+++ b/examples/eks-multicluster/versions.tf
@@ -18,8 +18,8 @@ terraform {
       configuration_aliases = [helm.eks_cluster_1, helm.eks_cluster_2]
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
   }
 }

--- a/examples/existing-cluster-java/README.md
+++ b/examples/existing-cluster-java/README.md
@@ -194,7 +194,7 @@ terraform destroy -var-file=terraform.tfvars
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/examples/existing-cluster-java/versions.tf
+++ b/examples/existing-cluster-java/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/existing-cluster-nginx/README.md
+++ b/examples/existing-cluster-nginx/README.md
@@ -205,7 +205,7 @@ add this `managed_prometheus_region=xxx` and `managed_prometheus_workspace_id=ws
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/examples/existing-cluster-nginx/versions.tf
+++ b/examples/existing-cluster-nginx/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/examples/existing-cluster-with-base-and-infra/README.md
+++ b/examples/existing-cluster-with-base-and-infra/README.md
@@ -22,7 +22,7 @@ View the full documentation for this example [here](https://aws-observability.gi
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/examples/existing-cluster-with-base-and-infra/versions.tf
+++ b/examples/existing-cluster-with-base-and-infra/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/eks-container-insights/README.md
+++ b/modules/eks-container-insights/README.md
@@ -15,7 +15,7 @@ It provides the following resources:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers

--- a/modules/eks-container-insights/versions.tf
+++ b/modules/eks-container-insights/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/eks-monitoring/README.md
+++ b/modules/eks-monitoring/README.md
@@ -22,7 +22,7 @@ See examples using this Terraform modules in the **Amazon EKS** section of [this
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
@@ -31,7 +31,7 @@ See examples using this Terraform modules in the **Amazon EKS** section of [this
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.4.1 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.3 |
 
 ## Modules
 
@@ -55,11 +55,11 @@ See examples using this Terraform modules in the **Amazon EKS** section of [this
 | [helm_release.grafana_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.kube_state_metrics](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus_node_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubectl_manifest.adothealth_monitoring_dashboards](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.api_server_dashboards](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.flux_gitrepository](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.kubeproxy_monitoring_dashboard](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.adothealth_monitoring_dashboards](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.api_server_dashboards](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_gitrepository](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.kubeproxy_monitoring_dashboard](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/modules/eks-monitoring/add-ons/external-secrets/README.md
+++ b/modules/eks-monitoring/add-ons/external-secrets/README.md
@@ -9,7 +9,7 @@ This deploys an EKS Cluster with the External Secrets Operator. The cluster is p
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
@@ -17,7 +17,7 @@ This deploys an EKS Cluster with the External Secrets Operator. The cluster is p
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.3 |
 
 ## Modules
 
@@ -33,8 +33,8 @@ This deploys an EKS Cluster with the External Secrets Operator. The cluster is p
 | [aws_iam_policy.cluster_secretstore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_kms_key.secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_ssm_parameter.secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [kubectl_manifest.cluster_secretstore](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubectl_manifest.secret](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.cluster_secretstore](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.secret](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs

--- a/modules/eks-monitoring/add-ons/external-secrets/versions.tf
+++ b/modules/eks-monitoring/add-ons/external-secrets/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
   }
 }

--- a/modules/eks-monitoring/patterns/istio/README.md
+++ b/modules/eks-monitoring/patterns/istio/README.md
@@ -13,7 +13,7 @@ Provides monitoring for Istio based workloads with the following resources:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
@@ -21,7 +21,7 @@ Provides monitoring for Istio based workloads with the following resources:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.3 |
 
 ## Modules
 
@@ -33,7 +33,7 @@ No modules.
 |------|------|
 | [aws_prometheus_rule_group_namespace.alerting_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
 | [aws_prometheus_rule_group_namespace.recording_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
-| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 
 ## Inputs
 

--- a/modules/eks-monitoring/patterns/istio/versions.tf
+++ b/modules/eks-monitoring/patterns/istio/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/eks-monitoring/patterns/java/README.md
+++ b/modules/eks-monitoring/patterns/java/README.md
@@ -13,7 +13,7 @@ Provides monitoring for Java based workloads with the following resources:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.4.1 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
@@ -21,7 +21,7 @@ Provides monitoring for Java based workloads with the following resources:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.3 |
 
 ## Modules
 
@@ -33,7 +33,7 @@ No modules.
 |------|------|
 | [aws_prometheus_rule_group_namespace.alerting_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
 | [aws_prometheus_rule_group_namespace.recording_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
-| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 
 ## Inputs
 

--- a/modules/eks-monitoring/patterns/java/versions.tf
+++ b/modules/eks-monitoring/patterns/java/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/eks-monitoring/patterns/nginx/README.md
+++ b/modules/eks-monitoring/patterns/nginx/README.md
@@ -14,7 +14,7 @@ It provides the following resources:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.14 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 2.0.3 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 
 ## Providers
@@ -22,7 +22,7 @@ It provides the following resources:
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.14 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 2.0.3 |
 
 ## Modules
 
@@ -33,7 +33,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_prometheus_rule_group_namespace.alerting_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/prometheus_rule_group_namespace) | resource |
-| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_kustomization](https://registry.terraform.io/providers/alekc/kubectl/latest/docs/resources/manifest) | resource |
 
 ## Inputs
 

--- a/modules/eks-monitoring/patterns/nginx/versions.tf
+++ b/modules/eks-monitoring/patterns/nginx/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
   }
 }

--- a/modules/eks-monitoring/versions.tf
+++ b/modules/eks-monitoring/versions.tf
@@ -11,8 +11,8 @@ terraform {
       version = ">= 2.10"
     }
     kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = ">= 1.14"
+      source  = "alekc/kubectl"
+      version = ">= 2.0.3"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### What does this PR do?

Fix issue with gavinbunney/kubectl on eks 1.28. Some resource disappear or re-created on every tf apply

Migrate to alekc/kubectl providers

close #244 

### Motivation

Make it work on every tf apply with eks 1.28

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
