### PR TITLE
chore: Bump to EKS 1.28

### DIFF
--- a/examples/eks-cluster-with-vpc/variables.tf
+++ b/examples/eks-cluster-with-vpc/variables.tf
@@ -26,5 +26,5 @@ variable "managed_node_min_size" {
 variable "eks_version" {
   type        = string
   description = "EKS Cluster version"
-  default     = "1.25"
+  default     = "1.28"
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
Default cluster creation to 1.28. We recently merged a PR to validate 1.28 https://github.com/aws-observability/terraform-aws-observability-accelerator/pull/245


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [x] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [x] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
