### PR TITLE
Update variables.tf

### DIFF
--- a/modules/managed-prometheus-monitoring/variables.tf
+++ b/modules/managed-prometheus-monitoring/variables.tf
@@ -11,13 +11,13 @@ variable "managed_prometheus_workspace_ids" {
 variable "active_series_threshold" {
   description = "Threshold for active series metric alarm"
   type        = number
-  default     = 1000000
+  default     = 8000000
 }
 
 variable "ingestion_rate_threshold" {
   description = "Threshold for active series metric alarm"
   type        = number
-  default     = 70000
+  default     = 136000
 }
 
 variable "dashboards_folder_id" {


### PR DESCRIPTION
Based on recommended settings from AMP Product manager. Active series auto scales to 10M metrics so we are setting to 80% of that or 8M. Ingestion scales along with active series so we are setting to 136,000


