### PR TITLE
Issue#229 changing v1beta2 to v1 for flux

### DIFF
--- a/modules/eks-monitoring/dashboards.tf
+++ b/modules/eks-monitoring/dashboards.tf
@@ -19,7 +19,7 @@ YAML
 
 resource "kubectl_manifest" "flux_kustomization" {
   yaml_body  = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${var.flux_kustomization_name}
@@ -50,7 +50,7 @@ YAML
 # api server dashboards
 resource "kubectl_manifest" "api_server_dashboards" {
   yaml_body  = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${local.apiserver_monitoring_config.flux_kustomization_name}
@@ -75,7 +75,7 @@ YAML
 # adot health dashboards
 resource "kubectl_manifest" "adothealth_monitoring_dashboards" {
   yaml_body  = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${local.adothealth_monitoring_config.flux_kustomization_name}
@@ -98,7 +98,7 @@ YAML
 # nvidia dashboards
 resource "kubectl_manifest" "nvidia_monitoring_dashboards" {
   yaml_body  = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${local.nvidia_monitoring_config.flux_kustomization_name}
@@ -117,7 +117,7 @@ YAML
 
 resource "kubectl_manifest" "kubeproxy_monitoring_dashboard" {
   yaml_body  = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${local.kubeproxy_monitoring_config.flux_kustomization_name}

--- a/modules/eks-monitoring/patterns/istio/main.tf
+++ b/modules/eks-monitoring/patterns/istio/main.tf
@@ -192,7 +192,7 @@ resource "kubectl_manifest" "flux_kustomization" {
   count = var.pattern_config.enable_dashboards ? 1 : 0
 
   yaml_body = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${var.pattern_config.flux_kustomization_name}

--- a/modules/eks-monitoring/patterns/java/main.tf
+++ b/modules/eks-monitoring/patterns/java/main.tf
@@ -36,7 +36,7 @@ resource "kubectl_manifest" "flux_kustomization" {
   count = var.pattern_config.enable_dashboards ? 1 : 0
 
   yaml_body = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${var.pattern_config.flux_kustomization_name}

--- a/modules/eks-monitoring/patterns/nginx/main.tf
+++ b/modules/eks-monitoring/patterns/nginx/main.tf
@@ -42,7 +42,7 @@ resource "kubectl_manifest" "flux_kustomization" {
   count = var.pattern_config.enable_dashboards ? 1 : 0
 
   yaml_body = <<YAML
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: ${var.pattern_config.flux_kustomization_name}


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.
#229  Updated the flux system kustomization API version on the new versions from v1beta2 to v1 to resolve dashboard issues on EKS 1.27+

### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
