### PR TITLE
(bugfix): Adot interpolation updates

### DIFF
--- a/.github/workflows/plan-examples.yml
+++ b/.github/workflows/plan-examples.yml
@@ -109,7 +109,7 @@ jobs:
                    - export TF_VAR_grafana_api_key="fakeapikey"
                    - curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
                    - sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-                   - sudo apt-get update && sudo apt-get install terraform
+                   - sudo apt-get update && sudo apt-get install -y terraform
                    - terraform -version
                    - aws --version
                    - cd ${{ matrix.directory }}

--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -102,7 +102,7 @@ spec:
               - source_labels: [__name__, le]
                 separator: ;
                 regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
-                replacement: $$1
+                replacement: $${1}
                 action: drop
             {{ end }}
 
@@ -118,70 +118,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (prometheus-node-exporter);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_jobLabel]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -193,12 +193,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -221,69 +221,69 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-prometheus);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_self_monitor, __meta_kubernetes_service_labelpresent_self_monitor]
                 separator: ;
                 regex: (true);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-web
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -295,12 +295,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -327,64 +327,64 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-operator);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: https
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -396,12 +396,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -432,70 +432,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name, __meta_kubernetes_service_labelpresent_app_kubernetes_io_name]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_k8s_app, __meta_kubernetes_service_labelpresent_k8s_app]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: https-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_k8s_app]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -506,19 +506,19 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: metrics_path
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__address__]
                 separator: ;
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -549,70 +549,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name, __meta_kubernetes_service_labelpresent_app_kubernetes_io_name]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_k8s_app, __meta_kubernetes_service_labelpresent_k8s_app]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: https-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_k8s_app]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -623,19 +623,19 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: metrics_path
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__address__]
                 separator: ;
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -665,70 +665,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name, __meta_kubernetes_service_labelpresent_app_kubernetes_io_name]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_k8s_app, __meta_kubernetes_service_labelpresent_k8s_app]
                 separator: ;
                 regex: (kubelet);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: https-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_k8s_app]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -739,19 +739,19 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: metrics_path
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__address__]
                 separator: ;
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -775,70 +775,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_instance, __meta_kubernetes_service_labelpresent_app_kubernetes_io_instance]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name, __meta_kubernetes_service_labelpresent_app_kubernetes_io_name]
                 separator: ;
                 regex: (kube-state-metrics);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -850,12 +850,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -881,70 +881,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-kube-scheduler);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_jobLabel]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -956,12 +956,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -989,7 +989,7 @@ spec:
                 action: replace
                 target_label: __address__
                 regex: (.+?)(\\:\\d+)?
-                replacement: $$1:10249
+                replacement: $${1}:10249
 
             - job_name: serviceMonitor/default/kube-prometheus-stack-kube-controller-manager/0
               honor_timestamps: true
@@ -1006,70 +1006,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-kube-controller-manager);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_jobLabel]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -1081,12 +1081,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -1112,70 +1112,70 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-coredns);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-metrics
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_jobLabel]
                 separator: ;
                 regex: (.+)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -1187,12 +1187,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -1213,69 +1213,69 @@ spec:
                 separator: ;
                 regex: (.*)
                 target_label: __tmp_prometheus_job_name
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_label_app, __meta_kubernetes_service_labelpresent_app]
                 separator: ;
                 regex: (kube-prometheus-stack-alertmanager);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_release, __meta_kubernetes_service_labelpresent_release]
                 separator: ;
                 regex: (kube-prometheus-stack);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_service_label_self_monitor, __meta_kubernetes_service_labelpresent_self_monitor]
                 separator: ;
                 regex: (true);true
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_port_name]
                 separator: ;
                 regex: http-web
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Node;(.*)
                 target_label: node
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_endpoint_address_target_kind, __meta_kubernetes_endpoint_address_target_name]
                 separator: ;
                 regex: Pod;(.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_namespace]
                 separator: ;
                 regex: (.*)
                 target_label: namespace
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: service
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_name]
                 separator: ;
                 regex: (.*)
                 target_label: pod
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_pod_container_name]
                 separator: ;
                 regex: (.*)
                 target_label: container
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - source_labels: [__meta_kubernetes_service_name]
                 separator: ;
                 regex: (.*)
                 target_label: job
-                replacement: $$1
+                replacement: $${1}
                 action: replace
               - separator: ;
                 regex: (.*)
@@ -1287,12 +1287,12 @@ spec:
                 regex: (.*)
                 modulus: 1
                 target_label: __tmp_hash
-                replacement: $$1
+                replacement: $${1}
                 action: hashmod
               - source_labels: [__tmp_hash]
                 separator: ;
                 regex: "0"
-                replacement: $$1
+                replacement: $${1}
                 action: keep
               kubernetes_sd_configs:
                 - role: endpoints
@@ -1445,14 +1445,14 @@ spec:
                 target_label: __metrics_path__
               - action: replace
                 regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-                replacement: '[$$2]:$$1'
+                replacement: '[$${2}]:$${1}'
                 source_labels:
                 - __meta_kubernetes_pod_annotation_prometheus_io_port
                 - __meta_kubernetes_pod_ip
                 target_label: __address__
               - action: replace
                 regex: (\d+);((([0-9]+?)(\.|$)){4})
-                replacement: $$2:$$1
+                replacement: $${2}:$${1}
                 source_labels:
                 - __meta_kubernetes_pod_annotation_prometheus_io_port
                 - __meta_kubernetes_pod_ip


### PR DESCRIPTION
### What does this PR do?

newer versions of ADOT forces interpolation changes from `$var` to `${var}`. Current installations are broken with such messages

```
{"level":"ERROR","timestamp":"2024-09-16T12:28:10Z","logger":"conversion-webhook","message":"failed to convert","requ │
│ est":"25310353-c5f2-408d-a0f7-3425e18ab95c","error":"failed to convert to v1beta1: could not convert config json to v │
│ 1beta1.Config","stacktrace":"[sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).ServeHTTP](http://sigs.k8s.io/controller-runtime/pkg/webhook/conversion.(*webhook).ServeHTTP)\n\t/home/runn │
│ er/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/webhook/conversion/conversion.go:74\[nsigs.k8s.io/controller-](http://nsigs.k8s.io/controller-) │
│ runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1\n\t/home/runner/go/pkg/mod/gith │
│ [ub.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:60](http://ub.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:60)\nnet/http.HandlerFunc.ServeHTTP\n │
│ \t/opt/hostedtoolcache/go/1.21.12/x64/src/net/http/server.go:2141\[ngithub.com/prometheus/client_golang/prometheus/pro](http://ngithub.com/prometheus/client_golang/prometheus/pro) │
│ mhttp.InstrumentHandlerCounter.func1\n\t/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheu │
│ s/promhttp/instrument_server.go:147\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.12/x64/src/net/ht │
│ tp/server.go:2141\[ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2](http://ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2)\n\t/home/r │
│ unner/go/pkg/mod/github.com/prometheus/client_golang@v1.19.1/prometheus/promhttp/instrument_server.go:109\nnet/http.H │
│ andlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.12/x64/src/net/http/server.go:2141\nnet/http.(*ServeMux).ServeHT │
│ TP\n\t/opt/hostedtoolcache/go/1.21.12/x64/src/net/http/server.go:2519\nnet/http.serverHandler.ServeHTTP\n\t/opt/hoste │
│ dtoolcache/go/1.21.12/x64/src/net/http/server.go:2943\nnet/http.(*conn).serve\n\t/opt/hostedtoolcache/go/1.21.12/x64/ │
│ src/net/http/server.go:2014"}
```

This PR fixes the issue

PS: tests are currently broken so you have to "trust me"

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
