### PR TITLE
Add support for KCM and KSH metrics

### DIFF
--- a/modules/eks-monitoring/add-ons/adot-operator/main.tf
+++ b/modules/eks-monitoring/add-ons/adot-operator/main.tf
@@ -177,9 +177,9 @@ resource "kubernetes_cluster_role_v1" "adot" {
     verbs             = ["get"]
   }
   rule {
-    api_groups  = ["metrics.eks.amazonaws.com"]
-    verbs       = ["get"]
-    resources   = ["kcm/metrics", "ksh/metrics"]
+    api_groups = ["metrics.eks.amazonaws.com"]
+    verbs      = ["get"]
+    resources  = ["kcm/metrics", "ksh/metrics"]
   }
   rule {
     api_groups = [""]

--- a/modules/eks-monitoring/add-ons/adot-operator/main.tf
+++ b/modules/eks-monitoring/add-ons/adot-operator/main.tf
@@ -177,6 +177,11 @@ resource "kubernetes_cluster_role_v1" "adot" {
     verbs             = ["get"]
   }
   rule {
+    api_groups  = ["metrics.eks.amazonaws.com"]
+    verbs       = ["get"]
+    resources   = ["kcm/metrics", "ksh/metrics"]
+  }
+  rule {
     api_groups = [""]
     resources  = ["configmaps"]
     verbs      = ["create", "delete", "get", "list", "patch", "update", "watch"]

--- a/modules/eks-monitoring/otel-config/templates/clusterrole.yaml
+++ b/modules/eks-monitoring/otel-config/templates/clusterrole.yaml
@@ -23,6 +23,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - metrics.eks.amazonaws.com
+    resources:
+      - kcm/metrics
+      - ksh/metrics
+    verbs:
+      - get
   - nonResourceURLs:
       - /metrics
     verbs:

--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -104,6 +104,42 @@ spec:
                 regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
                 replacement: $${1}
                 action: drop
+            - job_name: 'ksh-metrics'
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: endpoints
+              metrics_path: /apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics
+              relabel_configs:
+              - source_labels:
+                  [
+                    __meta_kubernetes_namespace,
+                    __meta_kubernetes_service_name,
+                    __meta_kubernetes_endpoint_port_name,
+                  ]
+                action: keep
+                regex: default;kubernetes;https
+            - job_name: 'kcm-metrics'
+              scheme: https
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                insecure_skip_verify: true
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+              - role: endpoints
+              metrics_path: /apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics
+              relabel_configs:
+              - source_labels:
+                  [
+                    __meta_kubernetes_namespace,
+                    __meta_kubernetes_service_name,
+                    __meta_kubernetes_endpoint_port_name,
+                  ]
+                action: keep
+                regex: default;kubernetes;https
             {{ end }}
 
             - job_name: serviceMonitor/default/kube-prometheus-stack-prometheus-node-exporter/0


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

🛑 Please open an issue first to discuss any significant work and flesh out details/direction - we would hate for your time to be wasted. Consult the CONTRIBUTING guide for submitting pull-requests.

Scrape kube-scheduler, kube-controller-manager metrics

### Motivation

<!-- What inspired you to submit this pull request? -->

To provide visibility into ksh and kcm metrics.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR
- [ ] Yes, I have added a new example under [examples](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/examples) to support my PR (when applicable)
- [ ] Yes, I have updated the [Pages](https://github.com/aws-observability/terraform-aws-observability-accelerator/tree/main/docs) for this feature

**Note**: Not all the PRs required examples and docs.

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
