### PR TITLE
(bugfix): OpentelemetryCollector Fix configuration

### DIFF
--- a/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
+++ b/modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml
@@ -1527,7 +1527,7 @@ spec:
           authenticator: sigv4auth
         resource_to_telemetry_conversion:
           enabled: true
-      logging:
+      debug:
         verbosity: {{ .Values.adotLoglevel }}
     extensions:
       sigv4auth:
@@ -1539,6 +1539,7 @@ spec:
           sts_region: {{ .Values.region }}
         {{ end }}
       health_check:
+        endpoint: 0.0.0.0:13133
       pprof:
         endpoint: :1888
       zpages:
@@ -1569,7 +1570,7 @@ spec:
         metrics:
           receivers: [prometheus, otlp]
           processors: [batch/metrics, attributes/metrics]
-          exporters: [logging, prometheusremotewrite]
+          exporters: [debug, prometheusremotewrite]
         {{ if .Values.enableAdotcollectorMetrics }}
         metrics/1:
           receivers: [prometheus/1]
@@ -1580,7 +1581,7 @@ spec:
         traces:
           receivers: [otlp]
           processors: [batch/traces]
-          exporters: [logging, awsxray]
+          exporters: [debug, awsxray]
         {{ end }}
       {{ if .Values.enableAdotcollectorMetrics }}
       telemetry:


### PR DESCRIPTION
This pull request updates the OpenTelemetry Collector configuration in the `modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yaml` file to enhance logging and debugging capabilities and improve monitoring. The most important changes include replacing the `logging` exporter with a `debug` exporter, adding a health check endpoint, and updating the exporters for metrics and traces.

Ref : https://github.com/open-telemetry/opentelemetry-collector/issues/11337

### Logging and Debugging Enhancements:
* Replaced the `logging` exporter with a `debug` exporter for improved debugging capabilities. (`spec:` in `opentelemetrycollector.yaml`, [modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yamlL1530-R1530](diffhunk://#diff-b3ca8c460ff8d9bb022f2fb40b899112c18133e166987f60258f4f0f82e4e709L1530-R1530))

### Monitoring Improvements:
* Added a health check endpoint (`0.0.0.0:13133`) to the configuration for better observability. (`spec:` in `opentelemetrycollector.yaml`, [modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yamlR1542](diffhunk://#diff-b3ca8c460ff8d9bb022f2fb40b899112c18133e166987f60258f4f0f82e4e709R1542))
* Updated the exporters for metrics to use `[debug, prometheusremotewrite]` instead of `[logging, prometheusremotewrite]`. (`spec:` in `opentelemetrycollector.yaml`, [modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yamlL1572-R1573](diffhunk://#diff-b3ca8c460ff8d9bb022f2fb40b899112c18133e166987f60258f4f0f82e4e709L1572-R1573))
* Updated the exporters for traces to use `[debug, awsxray]` instead of `[logging, awsxray]`. (`spec:` in `opentelemetrycollector.yaml`, [modules/eks-monitoring/otel-config/templates/opentelemetrycollector.yamlL1583-R1584](diffhunk://#diff-b3ca8c460ff8d9bb022f2fb40b899112c18133e166987f60258f4f0f82e4e709L1583-R1584))### What does this PR do?

