### PR TITLE
feat(eks-monitoring): Add OTel enrichment support for vended metrics

### DIFF
--- a/examples/eks-cloudwatch-otlp/main.tf
+++ b/examples/eks-cloudwatch-otlp/main.tf
@@ -19,6 +19,9 @@ module "eks_monitoring" {
   eks_cluster_id         = var.eks_cluster_id
   cw_agent_addon_version = "v6.0.1-eksbuild.1"
 
+  # OTel enrichment — enables resource tags + PromQL for vended metrics
+  enable_otel_enrichment = true
+
   # OTLP gateway — deploys CWA as a Deployment accepting app telemetry
   enable_otlp_gateway = true
 

--- a/modules/eks-monitoring/outputs.tf
+++ b/modules/eks-monitoring/outputs.tf
@@ -95,3 +95,12 @@ output "otlp_gateway_endpoint" {
     http = "http://${local.otlp_gateway_name}.${local.otlp_gateway_namespace}:4316"
   } : null
 }
+
+#--------------------------------------------------------------
+# OTel Enrichment Output
+#--------------------------------------------------------------
+
+output "otel_enrichment_enabled" {
+  description = "Whether OTel enrichment for vended metrics is enabled in this account"
+  value       = var.enable_otel_enrichment
+}

--- a/modules/eks-monitoring/variables.tf
+++ b/modules/eks-monitoring/variables.tf
@@ -207,6 +207,12 @@ variable "node_exporter_chart_version" {
 # CloudWatch Agent Variables (cloudwatch-otlp profile)
 #--------------------------------------------------------------
 
+variable "enable_otel_enrichment" {
+  type        = bool
+  description = "Enable CloudWatch OTel enrichment for vended metrics. Enables resource tags on telemetry and PromQL access for enriched metrics. Account-level singletons — only enable in one module instance per account."
+  default     = false
+}
+
 variable "enable_otlp_gateway" {
   type        = bool
   description = "Deploy a CWA Deployment as an OTLP gateway for application metrics/traces/logs. Apps send OTLP to this gateway, which forwards to CloudWatch. Only applies to cloudwatch-otlp profile."

--- a/modules/eks-monitoring/versions.tf
+++ b/modules/eks-monitoring/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = ">= 6.42.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
Uncomment and wire up aws_observabilityadmin_telemetry_enrichment and aws_cloudwatch_otel_enrichment resources, gated by enable_otel_enrichment variable. Both are account-level singletons available since AWS provider v6.38.0 and v6.42.0 respectively.

- Add enable_otel_enrichment variable (default false)
- Bump AWS provider constraint to >= 6.42.0
- Add otel_enrichment_enabled output
- Enable enrichment by default in eks-cloudwatch-otlp example

